### PR TITLE
Add controller event listener to service definition

### DIFF
--- a/src/Resources/config/services/event_listener.xml
+++ b/src/Resources/config/services/event_listener.xml
@@ -9,6 +9,14 @@
             <tag name="kernel.event_listener" event="sylius.menu.admin.main" method="addAdminMenuItems"/>
         </service>
 
+        <service id="setono_sylius_redirect.event_listener.controller"
+                 class="Setono\SyliusRedirectPlugin\EventListener\ControllerSubscriber">
+            <argument type="service" id="setono_sylius_redirect.manager.redirect"/>
+            <argument type="service" id="sylius.context.channel"/>
+            <argument type="service" id="setono_sylius_redirect.resolver.redirection_path"/>
+            <tag name="kernel.event_subscriber"/>
+        </service>        
+        
         <service id="setono_sylius_redirect.event_listener.not_found"
                  class="Setono\SyliusRedirectPlugin\EventListener\NotFoundSubscriber">
             <argument type="service" id="setono_sylius_redirect.manager.redirect"/>


### PR DESCRIPTION
The not found subscriber was registered, shouldn't the controller one also be registered? I had trouble finding it under `bin/console debug:event-dispatcher kernel.controller` until I added this.