### PR TITLE
Usage of the the new Doctrine Persistence API

### DIFF
--- a/spec/EventListener/ControllerSubscriberSpec.php
+++ b/spec/EventListener/ControllerSubscriberSpec.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace spec\Setono\SyliusRedirectPlugin\EventListener;
 
 use Closure;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Setono\SyliusRedirectPlugin\EventListener\ControllerSubscriber;

--- a/spec/EventListener/NotFoundSubscriberSpec.php
+++ b/spec/EventListener/NotFoundSubscriberSpec.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace spec\Setono\SyliusRedirectPlugin\EventListener;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Setono\SyliusRedirectPlugin\EventListener\NotFoundSubscriber;

--- a/src/EventListener/ControllerSubscriber.php
+++ b/src/EventListener/ControllerSubscriber.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Setono\SyliusRedirectPlugin\EventListener;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Setono\SyliusRedirectPlugin\Resolver\RedirectionPathResolverInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/src/EventListener/NotFoundSubscriber.php
+++ b/src/EventListener/NotFoundSubscriber.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Setono\SyliusRedirectPlugin\EventListener;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Setono\SyliusRedirectPlugin\Resolver\RedirectionPathResolverInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;


### PR DESCRIPTION
This PR fixes the usage of the "old" Doctrine Persistence API in the controllers, making it compatible with Sylius 1.9
See issues #71 