### PR TITLE
Do not throw if channel does not exist on current request

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -21,6 +21,7 @@
     "Sylius\\Bundle\\TaxonomyBundle\\Form\\Type\\TaxonTranslationType",
     "Sylius\\Bundle\\UiBundle\\Menu\\Event\\MenuBuilderEvent",
     "Sylius\\Component\\Channel\\Context\\ChannelContextInterface",
+    "Sylius\\Component\\Channel\\Context\\ChannelNotFoundException",
     "Sylius\\Component\\Channel\\Model\\ChannelAwareInterface",
     "Sylius\\Component\\Channel\\Model\\ChannelInterface",
     "Sylius\\Component\\Channel\\Model\\ChannelsAwareInterface",

--- a/src/EventListener/ControllerSubscriber.php
+++ b/src/EventListener/ControllerSubscriber.php
@@ -7,6 +7,7 @@ namespace Setono\SyliusRedirectPlugin\EventListener;
 use Doctrine\Persistence\ObjectManager;
 use Setono\SyliusRedirectPlugin\Resolver\RedirectionPathResolverInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -45,9 +46,15 @@ final class ControllerSubscriber implements EventSubscriberInterface
     public function onKernelController(ControllerEvent $event): void
     {
         $request = $event->getRequest();
+        $channel = null;
+
+        try {
+            $channel = $this->channelContext->getChannel();
+        } catch (ChannelNotFoundException $e) {
+        }
         $redirectionPath = $this->redirectionPathResolver->resolveFromRequest(
             $request,
-            $this->channelContext->getChannel()
+            $channel
         );
 
         if ($redirectionPath->isEmpty()) {

--- a/src/EventListener/NotFoundSubscriber.php
+++ b/src/EventListener/NotFoundSubscriber.php
@@ -8,6 +8,7 @@ use Doctrine\Persistence\ObjectManager;
 use Setono\MainRequestTrait\MainRequestTrait;
 use Setono\SyliusRedirectPlugin\Resolver\RedirectionPathResolverInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
@@ -57,11 +58,17 @@ class NotFoundSubscriber implements EventSubscriberInterface
         if (!$throwable instanceof HttpException || $throwable->getStatusCode() !== Response::HTTP_NOT_FOUND) {
             return;
         }
+        $channel = null;
+
+        try {
+            $channel = $this->channelContext->getChannel();
+        } catch (ChannelNotFoundException $e) {
+        }
 
         $request = $event->getRequest();
         $redirectionPath = $this->redirectionPathResolver->resolveFromRequest(
             $request,
-            $this->channelContext->getChannel(),
+            $channel,
             true
         );
 


### PR DESCRIPTION
I think the plugin should not be responsible to throw an exception if the channel does not exist on the current request, so we should catch the exception!